### PR TITLE
깃허브 코드 업로드 시 이미 제출된 코드와 충돌하는 버그 수정

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>SongAlgo</title>
-  <script type="module" crossorigin src="/assets/index.4ba27b8c.js"></script>
+  <script type="module" crossorigin src="/assets/index.4e5a971f.js"></script>
   <link rel="stylesheet" href="/assets/index.1b1c92bc.css">
 </head>
 <body>

--- a/selenium/baekjoon.go
+++ b/selenium/baekjoon.go
@@ -180,8 +180,9 @@ func convertBjIdToGithubId(bjId string) (githubId string) {
 }
 
 func GetGithubRepositoryBjSource(problemTitle string, problemDate string, bjId string, language string) (github.File, error) {
+	dateString := convertDateString(problemDate)
 	branchName := convertBjIdToGithubId(bjId)
 	extension := convertCodeLanguageToFileExtension(language)
-	path := fmt.Sprintf("%s/%s.%s", problemDate, problemTitle, extension)
+	path := fmt.Sprintf("%s/%s.%s", dateString, problemTitle, extension)
 	return github.GetGithubRepositorySource(branchName, path)
 }


### PR DESCRIPTION
깃허브 코드 업로드 시, 해당 문제의 날짜를 YYMMDD 형식으로 수정하지 않아서 충돌 발생했다.